### PR TITLE
add reference example to schema

### DIFF
--- a/WIS2_Message_Format_Schema.yaml
+++ b/WIS2_Message_Format_Schema.yaml
@@ -113,3 +113,5 @@ required:
   - geometry
   - properties
   - links
+example:
+  $ref: https://raw.githubusercontent.com/wmo-im/wis2-notification-message/main/WIS2_Message_Format_Example_1.json


### PR DESCRIPTION
This PR adds an example payload to the YAML schema (by reference), to support schema renderers which are able to display an inline example of a given structure/payload.