### PR TITLE
Update WIS2_Message_Format_README.adoc

### DIFF
--- a/WIS2_Message_Format_README.adoc
+++ b/WIS2_Message_Format_README.adoc
@@ -90,8 +90,8 @@ It must be noted that the *geometry* key is mandatory in GeoJSON but can be of t
 |*properties*
 |Array
 |`{
-    "pubtime": "20220320T045018.314854383Z",
-    "datetime": "20220320T044500Z",
+    "pubtime": "2022-03-20T04:50:18.314854383Z",
+    "datetime": "2022-03-20T04:45:00Z",
     "integrity": {
         "method": "sha512",
         "value": "A2KNxvks...S8qfSCw=="
@@ -184,10 +184,10 @@ It must be noted that the *geometry* key is mandatory in GeoJSON but can be of t
 | Key | Value(s) | Example | Status | Description
 
 |*pubtime*
-|Date/Time in RFC 3339 format 
-|`20220320T045018.314854383Z`
+|Date/Time in RFC 3339 format. 
+|`2022-03-20T04:50:18.314854383Z`
 |Mandatory
-|Identifies the date/time of when the file was posted/published, in RFC3339 format. The publication date/time is critical for subscribers to prevent message loss by knowing their lag (how far behind the publisher they are).
+|Identifies the date/time of when the file was posted/published, in RFC3339 format. The publication date/time is critical for subscribers to prevent message loss by knowing their lag (how far behind the publisher they are). Only Z time zone is accepted.
 |*data_id*
 |element of the topic tree and unique identifier
 |`wis2/CAN/eccc-msc/data/core/weather/surface-based-obs/landFixed/UANT01_CWAO_200445___15103.bufr4`
@@ -198,21 +198,21 @@ It must be noted that the *geometry* key is mandatory in GeoJSON but can be of t
 by the originating center as long as it is unique over a 1 week period.
 |*datetime*
 |Date/Time in RFC 3339 format 
-|`20220320T045018`
+|`2022-03-20T04:50:18`
 |Optional (and exclusive of start_ and end_datetime)
-|Identifies the date/time of the data being published, in RFC3339 format. E.g. for observation data, date of measurement.
+|Identifies the date/time of the data being published, in RFC3339 format. E.g. for observation data, date of measurement. Only Z time zone is accepted.
 |*start_datetime*
 |Date/Time in RFC 3339 format 
-|`20220320T045018`
+|`2022-03-20T04:50:18`
 |Optional (and exclusive of datetime). +
 Mandatory if end_datetime is included.
-|Identifies the start date/time of the data being published, in RFC3339 format. E.g., for NWP product, start of the forecasting period.
+|Identifies the start date/time of the data being published, in RFC3339 format. E.g., for NWP product, start of the forecasting period. Only Z time zone is accepted.
 |*end_datetime*
 |Date/Time in RFC 3339 format 
-|`20220320T045018`
+|`2022-03-20T04:50:18`
 |Optional (and exclusive of datetime). +
 Mandatory if start_datetime is included.
-|Identifies the end date/time of the data being published, in RFC3339 format. E.g., for NWP product, end of the forecasting period.
+|Identifies the end date/time of the data being published, in RFC3339 format. E.g., for NWP product, end of the forecasting period. Only Z time zone is accepted.
 |*integrity*
 |Array
 |`{


### PR DESCRIPTION
The dates examples were not RFC3339 compliant. And make "Z" time zone mandatory. This site gives good examples of the compliance aspects https://ijmacd.github.io/rfc3339-iso8601/