### PR TITLE
Adjust refs

### DIFF
--- a/WIS2_Message_Format_README.adoc
+++ b/WIS2_Message_Format_README.adoc
@@ -42,7 +42,7 @@ Having message in GeoJSON format will, for example, allow the use of standard va
     "content": {
         "encoding": "utf-8",
         "value": "encoded bytes from the file",
-        "length": 457
+        "size": 457
     }
 },
 "links": [
@@ -100,7 +100,7 @@ It must be noted that the *geometry* key is mandatory in GeoJSON but can be of t
     "content": {
         "encoding": "utf-8",
         "value": "encoded bytes from the file",
-        "length": 457
+        "size": 457
     }
 }`
 |Mandatory
@@ -226,7 +226,7 @@ Mandatory if start_datetime is included.
 |`{
         "encoding": "utf-8",
         "value": "encoded bytes from the file",
-        "length": 457
+        "size": 457
     }`
 |Optional
 |
@@ -273,11 +273,11 @@ It is _possible_ (but not mandatory) to include in the message the data. For sma
 |`encoded bytes from the file`
 |Mandatory
 |The UTF-8 version of the data. 
-|*length*
-|Int (*MUST* be below 2048)
+|*size*
+|integer (*MUST* be below 2048)
 |`1056`
 |Mandatory
-|The length of the data encoded in UTF-8. The value MUST be below 2048. Global Brokers might discard messages with *length* above 2048 bytes.
+|The size of the data encoded in UTF-8. The value MUST be below 2048. Global Brokers might discard messages with *size* above 2048 bytes.
 |===
 
 [id=links]
@@ -304,5 +304,10 @@ The _links_ array includes one or more URLs to give access to data.
 |`application/x-grib`
 |Mandatory
 |The MIME type of the data.
+|*length*
+|integer
+|`8804`
+|Optional
+|The length (in bytes) indicating the size of the data in the response when downloading the link.
 |===
 

--- a/WIS2_Message_Format_Schema.yaml
+++ b/WIS2_Message_Format_Schema.yaml
@@ -81,7 +81,7 @@ properties:
             enum:
               - utf-8
               - base64
-          size:
+          length:
             type: integer
             description: Number of bytes contained in the file. Together with the ``integrity`` property, it provides additional assurance that file content was accurately received.
             # RGiraud: Can we limit the size of the embedded data here?
@@ -90,7 +90,7 @@ properties:
             description: the inline content of the file.
         required:
           - encoding
-          - size
+          - length
     required:
       - pubtime
       - data_id

--- a/WIS2_Message_Format_Schema.yaml
+++ b/WIS2_Message_Format_Schema.yaml
@@ -1,11 +1,72 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: https://schemas.wmo.int/wis2/broker/message/0.9.0/schema.yml
-# RGiraud: That link doesn't exists. 
 title: WMO WIS 2.0 broker message schema
 description: WMO WIS 2.0 broker message schema
 
-type: object
+definitions:
+  schemas:
+    link:
+      type: object
+      required:
+        - href
+        - rel
+      properties:
+        href:
+          type: string
+          example: http://data.example.com/buildings/123
+        rel:
+          type: string
+          example: canonical
+        type:
+          type: string
+          example: application/geo+json
+        hreflang:
+          type: string
+          example: en
+        title:
+          type: string
+          example: Trierer Strasse 70, 53115 Bonn
+        length:
+          type: integer
+    pointGeoJSON:
+      # from https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/schemas/pointGeoJSON.yaml
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - Point
+        coordinates:
+          type: array
+          minItems: 2
+          items:
+            type: number
+    polygonGeoJSON:
+      # from https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/schemas/polygonGeoJSON.yaml
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - Polygon
+        coordinates:
+          type: array
+          items:
+            type: array
+            minItems: 4
+            items:
+              type: array
+              minItems: 2
+              items:
+                type: number
 
+type: object
 properties:
   id: 
     type: string
@@ -15,11 +76,15 @@ properties:
     type: string
     description: Version of message specification
     const: v04
+  type:
+    type: string
+    enum:
+      - Feature
   geometry:
     oneOf:
       - type: 'null'
-      - $ref: https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/schemas/pointGeoJSON.yaml
-      - $ref: https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/schemas/polygonGeoJSON.yaml
+      - $ref: '#/definitions/schemas/pointGeoJSON'
+      - $ref: '#/definitions/schemas/polygonGeoJSON'
   properties:
     type: object
     properties:
@@ -101,8 +166,7 @@ properties:
   links:
     type: array
     items:
-      $ref: https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/core/openapi/schemas/link.yaml
-    # RGiraud: How do we restrict links to be preferably HTTPS and SFTP and possibly HTTP and FTP, nothing else.
+      $ref: '#/definitions/schemas/link'
 required:
   - id
   - version

--- a/WIS2_Message_Format_Schema.yaml
+++ b/WIS2_Message_Format_Schema.yaml
@@ -146,7 +146,7 @@ properties:
             enum:
               - utf-8
               - base64
-          length:
+          size:
             type: integer
             description: Number of bytes contained in the file. Together with the ``integrity`` property, it provides additional assurance that file content was accurately received.
             # RGiraud: Can we limit the size of the embedded data here?
@@ -155,7 +155,7 @@ properties:
             description: the inline content of the file.
         required:
           - encoding
-          - length
+          - size
     required:
       - pubtime
       - data_id


### PR DESCRIPTION
- make refs inline (given they are stable/hardened)
- update `properties.content` to use `size` and keep `links` to use length, per OGC API - Features

cc @golfvert @maaikelimper 