### PR TITLE
Add SHA3 remove MD5 and arbitrary integrity values

### DIFF
--- a/schemas/notificationMessageGeoJSON.yaml
+++ b/schemas/notificationMessageGeoJSON.yaml
@@ -131,15 +131,19 @@ properties:
             type: string
             description: |
                 A specific set of methods for calculating the checksum algorithms:
-                * ``sha256``: the Secure Hash Algorithm 256 bits, value is base64 encoded.
-                * ``sha512``: the Secure Hash Algorithm 512 bits, value is base64 encoded.
-                * ``arbitrary``: an arbitrary string is used to identify the value.
-                * ``md5``: the Message Digest 5 hash (obsolete, perhaps will be rejected)
+                * ``sha256``: the Secure Hash Algorithm 2, 256 bits, value is base64 encoded.
+                * ``sha384``: the Secure Hash Algorithm 2, 384 bits, value is base64 encoded.
+                * ``sha512``: the Secure Hash Algorithm 2, 512 bits, value is base64 encoded.
+                * ``sha3-256``: the Secure Hash Algorithm 3, 256 bits, value is base64 encoded.
+                * ``sha3-384``: the Secure Hash Algorithm 3, 384 bits, value is base64 encoded.
+                * ``sha3-512``: the Secure Hash Algorithm 3, 512 bits, value is base64 encoded.
             enum:
               - sha256
+              - sha384
               - sha512
-              - arbitrary
-              - md5
+              - sha3-256
+              - sha3-384
+              - sha3-512
           value:
             type: string
             description: checksum value.

--- a/standard/recommendations/core/REC_integrity.adoc
+++ b/standard/recommendations/core/REC_integrity.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/integrity*
-^|A |A WNM SHOULD provide a `+properties.integrity+` property, consisting of a `+method+` property identifying the hashing method (``md5``, ``sha256``, ``sha512``) and a `+value+` property of the hashing result, when it can be easily derived.
+^|A |A WNM SHOULD provide a `+properties.integrity+` property, consisting of a `+method+` property identifying the hashing method (``sha256``, ``sha384``, ``sha512``, ``sha3-256``, ``sha3-384``, ``sha3-512``) and a `+value+` property of the hashing result, when it can be easily derived.
 |===

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -220,9 +220,9 @@ For data verification, it is suggested (but not mandatory) to include data integ
 that a given data granule has not been corrupted during download.
 
 The ``method`` property provides a format of the hashing method used to enable integrity check of the data. Acceptable values
-are ``md5``, ``sha256`` and ``sha512``.  ``sha512`` is preferred.
+are ``sha256``, ``sha384``, ``sha512``, ``sha3-256``, ``sha3-384``, and ``sha3-512``.  ``sha512`` is preferred.
 
-The ``value`` property provides the result of the hashing method.
+The ``value`` property provides the result of the hashing method, base64 or hexadecimally encoded.
 
 include::../recommendations/core/REC_integrity.adoc[]
 
@@ -232,7 +232,7 @@ include::../recommendations/core/REC_integrity.adoc[]
   ...
   "integrity": {
     "method": "sha512",
-    "value": "3bb12eda3c298db5de25597f54d924f2e17e78a26ad89...b0124ecb8a"
+    "value": "CPvTLiOfYRgfL3YNF/KKElwamwvLQwnzd96VnF2WoYuuH+hVIbwFSPQHHd/qa/fNVUBckviC5/HZs3Nx2jXEsA=="
   }
   ...
 }


### PR DESCRIPTION
I have removed mentions of MD5 and 'arbitrary' as integrity methods and added SHA2 with 384-bit length and three versions of SHA3 (256, 384 and 512 bits). What remains open is the encoding. In some examples, we show hexadecimal encoding, in the schema we mention only base64 so in the text I put both. Not sure if this ambiguity is good, but I guess everybody is adjusted to it already.