### PR TITLE
adjust spec URI

### DIFF
--- a/standard/abstract_tests/ATS_class_core.adoc
+++ b/standard/abstract_tests/ATS_class_core.adoc
@@ -1,7 +1,7 @@
 [[ats_core]]
 ====
 [%metadata]
-label:: http://www.wmo.int/spec/wnm/1.0/conf/core
+label:: http://www.wmo.int/spec/wnm/1/conf/core
 subject:: Requirements Class "core"
 classification:: Target Type:Notification Metadata
 ====

--- a/standard/asciidoc-link-check-config.json
+++ b/standard/asciidoc-link-check-config.json
@@ -1,7 +1,6 @@
 {
     "ignorePatterns": [
         { "pattern": "^http://www.opengis.net/def"},
-        { "pattern": "http://www.wmo.int/spec/wnm/1.0/conf/core" },
-        { "pattern": "http://www.wmo.int/spec/wnmmessage/1.0/req/core" }
+        { "pattern": "http://www.wmo.int/spec/wnm/1" }
     ]
 }

--- a/standard/requirements/requirements_class_core.adoc
+++ b/standard/requirements/requirements_class_core.adoc
@@ -2,7 +2,7 @@
 [cols="1,4",width="90%"]
 |===
 2+|*Requirements Class*
-2+|http://www.wmo.int/spec/wnm/1.0/req/core
+2+|http://www.wmo.int/spec/wnm/1/req/core
 |Target type |Notification Metadata
 |Dependency |<<rfc8259,IETF RFC8259: The JavaScript Object Notation (JSON) Data Interchange Format>>
 |Dependency |<<json-schema, JSON Schema>>

--- a/standard/sections/clause_5_conventions.adoc
+++ b/standard/sections/clause_5_conventions.adoc
@@ -4,7 +4,7 @@ This section provides details and examples for any conventions used in the docum
 === Identifiers
 The normative provisions in this Standard are denoted by the URI:
 
-http://wis.wmo.int/spec/wnm/1.0
+http://wis.wmo.int/spec/wnm/1
 
 All requirements and conformance tests that appear in this document are denoted by partial URIs which are relative to this base.
 


### PR DESCRIPTION
Similar to [WCMP2 updates](https://github.com/wmo-im/wcmp2/pull/104), update of the specification base URI from http://www.wmo.int/spec/wnm/1.0/conf/core to http://www.wmo.int/spec/wnm/1/conf/core, the main reason is being able to issue WNM releases in the 1.x series over time without change to the spec URI per se.