### PR TITLE
Changed repetitive references to WNM in requirements

### DIFF
--- a/standard/recommendations/core/PER_links.adoc
+++ b/standard/recommendations/core/PER_links.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Permission {counter:per-id}* |*/per/core/links*
-^|A |A WNM `+links+` array property MAY provide link objects which reference APIs or Web Accessible Folders (WAF).
+^|A |The `+links+` array property MAY provide link objects which reference APIs or Web Accessible Folders (WAF).
 |===

--- a/standard/recommendations/core/REC_data_id.adoc
+++ b/standard/recommendations/core/REC_data_id.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/data_id*
-^|A |A WNM `+properties.data_id+` property SHOULD NOT use an opaque id, but something meaningful to support client side filtering.
+^|A |The `+properties.data_id+` property SHOULD NOT use an opaque id, but something meaningful to support client side filtering.
 |===

--- a/standard/recommendations/core/REC_pubtime.adoc
+++ b/standard/recommendations/core/REC_pubtime.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/pubtime*
-^|A |For notifications of updates or deletions, a WNM `+properties.pubtime+` property SHOULD be updated in support of client handling of change detection.
+^|A |For notifications of updates or deletions, the `+properties.pubtime+` property SHOULD be updated in support of client handling of change detection.
 |===

--- a/standard/requirements/core/REQ_data_id.adoc
+++ b/standard/requirements/core/REQ_data_id.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/data_id*
 ^|A |A WNM SHALL provide a `+properties.data_id+` property.
-^|B |A WNM's `+properties.data_id+` property SHALL be unique.
+^|B |The `+properties.data_id+` property SHALL be unique.
 |===

--- a/standard/requirements/core/REQ_geometry.adoc
+++ b/standard/requirements/core/REQ_geometry.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/geometry*
 ^|A |A WNM SHALL provide a `+geometry+` property.
-^|B |A WNM's `+geometry+` property SHALL only provide one of a ``Point`` or ``Polygon`` geometry, or a ``null`` value when a geometry value is unknown or cannot be determined.
+^|B |The `+geometry+` property SHALL only provide one of a ``Point`` or ``Polygon`` geometry, or a ``null`` value when a geometry value is unknown or cannot be determined.
 |===

--- a/standard/requirements/core/REQ_id.adoc
+++ b/standard/requirements/core/REQ_id.adoc
@@ -2,7 +2,7 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/identifier*
-^|A |A WNM SHALL have an identifier via the `+id+` property.
-^|B |A WNM identifier SHALL be provided as a Universally Unique Identifier (UUID).
+^|A |A WNM SHALL provide an identifier via the `+id+` property.
+^|B |The `+id+` property SHALL be a Universally Unique Identifier (UUID).
 |===
 

--- a/standard/requirements/core/REQ_links.adoc
+++ b/standard/requirements/core/REQ_links.adoc
@@ -2,11 +2,11 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/links*
-^|A |A WNM SHALL define a `+links+` array property.
-^|B |A WNM's `+links+` array property SHALL contain at least one link with at least the required `+href+` and `+rel+` properties.
-^|C |A WNM's `+links+` array property SHALL contain links which, for core data, require no further action in order to download the resource.
-^|D |A WNM SHALL provide links using HTTP, HTTPS, FTP or SFTP.
-^|E |For new or updated data or metadata notifications, a WNM's `+links+` array property SHALL contain at least one link with an IANA link relation of `canonical` to clearly identify the preferred access link.
-^|F |For data or metadata update notifications, a WNM's `+links+` array property SHALL contain at least one link with a link relation of `http://def.wmo.int/def/rel/wnm/-/update` to clearly identify the preferred access link.
-^|G |For data or metadata deletions, a WNM's `+links+` array property SHALL contain at least one link with a link relation of `http://def.wmo.int/def/rel/wnm/-/deletion` to clearly identify data which has been deleted or removed.
+^|A |A WNM SHALL provide a `+links+` array property.
+^|B |The `+links+` array property SHALL provide at least one link with at least the required `+href+` and `+rel+` properties.
+^|C |The links for core data SHALL NOT require further action in order to download the resource.
+^|D |The links shall be HTTP, HTTPS, FTP or SFTP.
+^|E |For new or updated data or metadata notifications, the `+links+` array property SHALL provide at least one link with an IANA link relation of `canonical` to clearly identify the preferred access link.
+^|F |For data or metadata update notifications, the `+links+` array property SHALL provide at least one link with a link relation of `http://def.wmo.int/def/rel/wnm/-/update` to clearly identify the preferred access link.
+^|G |For data or metadata deletions, the `+links+` array property SHALL provide at least one link with a link relation of `http://def.wmo.int/def/rel/wnm/-/deletion` to clearly identify data which has been deleted or removed.
 |===

--- a/standard/requirements/core/REQ_pubtime.adoc
+++ b/standard/requirements/core/REQ_pubtime.adoc
@@ -3,6 +3,6 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/pubtime*
 ^|A |A WNM SHALL provide a `+properties.pubtime+` property.
-^|B |A WNM's `+properties.pubtime+` property SHALL be provided in RFC3339 format.
-^|C |A WNM's `+properties.pubtime+` property SHALL be provided in the UTC timezone.
+^|B |The `+properties.pubtime+` property SHALL be provided in RFC3339 format.
+^|C |The `+properties.pubtime+` property SHALL be provided in the UTC timezone.
 |===

--- a/standard/requirements/core/REQ_temporal.adoc
+++ b/standard/requirements/core/REQ_temporal.adoc
@@ -3,7 +3,7 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/temporal*
 ^|A |A WNM SHALL provide a temporal description by either a `+properties.datetime+` property or both the ``properties.start_datetime`` and ``properties.end_datetime`` properties.
-^|B |A WNM's temporal description SHALL be provided in RFC3339 format.
-^|C |A WNM's temporal description SHALL be provided in the UTC timezone.
-^|D |A WNM's temporal description SHALL be set to ``null`` (using only `+properties.datetime+`) when a temporal description cannot be derived.
+^|B |The temporal description SHALL be provided in RFC3339 format.
+^|C |The temporal description SHALL be provided in the UTC timezone.
+^|D |The temporal description SHALL be set to ``null`` (using only `+properties.datetime+`) when a temporal description cannot be derived.
 |===

--- a/standard/requirements/core/REQ_type.adoc
+++ b/standard/requirements/core/REQ_type.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/type*
 ^|A |A WNM SHALL provide a `+type+` property.
-^|B |A WNM's `+type+` property SHALL provide a fixed value of ``Feature``.
+^|B |The `+type+` property SHALL be a fixed value of ``Feature``.
 |===

--- a/standard/requirements/core/REQ_validation.adoc
+++ b/standard/requirements/core/REQ_validation.adoc
@@ -4,6 +4,6 @@
 ^|*Requirement {counter:req-id}* |*/req/core/validation*
 ^|A |Each WNM SHALL validate without error against the WNM schema.
 ^|B |Each WNM SHALL provide `+id+`, `+version+`, `+type+`, `+geometry+` and `+properties+` properties for GeoJSON compliance.
-^|C |Each WNM record `+type+` property SHALL be set to a fixed value of `+Feature+` for GeoJSON compliance.
+^|C |The `+type+` property SHALL be set to a fixed value of `+Feature+` for GeoJSON compliance.
 |===
 

--- a/standard/requirements/core/REQ_version.adoc
+++ b/standard/requirements/core/REQ_version.adoc
@@ -3,6 +3,6 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/version*
 ^|A |A WNM SHALL provide information on version conformance via the ``version`` property.
-^|B |A WNM's ``version`` property SHALL be fixed to ``v04`` for this version of the specification.
+^|B |The ``version`` property SHALL be fixed to ``v04`` for this version of the specification.
 |===
 


### PR DESCRIPTION
##DO NOT MERGE##

@tomkralidis @wmo-im/tt-wismd 

This PR is intended to show some ideas for normalization/simplification of the text in the requirements and recommendations. It is not a complete sweep but a sample to see if this makes sense.
  
To summarize: 
Where possible, I made the first requirement begin with "A WNM SHALL/SHOULD/MAY provide ``+xyz+`` property..." and subsequent reqs/recs begin with "The  ``+xyz+`` property SHALL/SHOULD/MAY provide..."

