### PR TITLE
7 data id required

### DIFF
--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -43,7 +43,7 @@ The table below provides an overview of the set of properties that may be includ
 |The date and time of when the notification was published, in RFC3339 format (see <<_properties_publication_time>>)
 
 |``properties.data_id``
-|**optional**
+|**required**
 |Unique identifier of the data as defined by the data producer (see <<data_id>>)
 
 |``properties.metadata_id``

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -47,35 +47,35 @@ The table below provides an overview of the set of properties that may be includ
 |Unique identifier of the data as defined by the data producer (see <<data_id>>)
 
 |``properties.metadata_id``
-|**optional**
+|optional
 |Identifier for associated discovery metadata record to which the notification applies (see <<metadata_id>>)
 
 |``properties.producer``
-|**optional**
+|optional
 |Identifies the provider that initially captured and processed the source data, in support of data distribution on behalf of other Members (see <<_properties_producer>>)
 
 |``properties.datetime``
-|**optional**
+|optional
 |Identifies the date and time of the data being published, in RFC3339 format (see <<_properties_temporal_description>>)
 
 |``properties.start_datetime``
-|**optional**
+|optional
 |Identifies the start date and time of the data being published, in RFC3339 format (see <<_properties_temporal_description>>)
 
 |``properties.end_datetime``
-|**optional**
+|optional
 |Identifies the end date and time of the data being published, in RFC3339 format (see <<_properties_temporal_description>>)
 
 |``properties.cache``
-|**optional**
+|optional
 |Indicates whether the data in the notification should be cached (if not specified, the default value is `true`) (see <<_properties_cache>>)
 
 |``properties.integrity``
-|**optional**
+|optional
 |Specifies a checksum to be applied to the data to ensure that the download is accurate (see <<_properties_integrity>>)
 
 |``properties.content``
-|**optional**
+|optional
 |Used to embed small products inline within the message (see <<_properties_content>>)
 
 |``links``

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -385,7 +385,8 @@ The ``links`` array property consists of one or more objects providing URLs to a
 Each link object provides:
 
 * an ``href`` property with a fully qualified link to access the data
-* a ``rel`` property providing an IANA link relation footnote:[https://www.iana.org/assignments/link-relations/link-relations.xhtml] describing the relationship between the link and the message
+* a ``rel`` property providing an IANA link relation footnote:[https://www.iana.org/assignments/link-relations/link-relations.xhtml] or WCMP2
+ defined extensionsfootnote:[https://github.com/wmo-im/wcmp2-codelists/blob/main/codelists/link-type.csv] describing the relationship between the link and the message
 * a ``type`` property providing the media type of the data
 * a ``length`` property providing the length (in bytes) indicating the size of the data
 * a ``security`` property providing a description of the access control mechanism applied (i.e., for recommended data)

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -331,7 +331,7 @@ For data verification, it is recommended to include data integrity information v
 that a given data granule has not been corrupted during download.
 
 The ``method`` property provides a format of the hashing method used to enable an integrity check of the data. The preferred values
-are ``sha256``, ``sha384``, ``sha512``, ``sha3-256``, ``sha3-384``, and ``sha3-512``.  ``sha512``.
+are ``sha256``, ``sha384``, ``sha512``, ``sha3-256``, ``sha3-384``, and ``sha3-512``.
 
 The ``value`` property provides the result of the hashing method in base64 encoding.
 


### PR DESCRIPTION
- properties.data-id was optional so changed to required, 
- changed optional not to be bold
- removed duplicate of sha512 under Properties / Integrity
- added "or WCMP2
 defined extensionsfootnote:[https://github.com/wmo-im/wcmp2-codelists/blob/main/codelists/link-type.csv]" for rel under links