### PR TITLE
add requirement for metadata deletion (#114)

### DIFF
--- a/standard/requirements/core/REQ_links.adoc
+++ b/standard/requirements/core/REQ_links.adoc
@@ -9,4 +9,5 @@
 ^|E |For new data and metadata notifications, the `+links+` array property SHALL provide at least one link with an IANA link relation of `canonical` to clearly identify the preferred access link.
 ^|F |For data or metadata update notifications, the `+links+` array property SHALL provide at least one link with a link relation of `update` to clearly identify the preferred access link.
 ^|G |For data or metadata deletions, the `+links+` array property SHALL provide at least one link with a link relation of `deletion` to clearly identify data which has been deleted or removed.
+^|H |For metadata deletions, the `properties.metadata_id` property SHALL be specified to support deletion of a WCMP2 record from the Global Discovery Catalogue.
 |===


### PR DESCRIPTION
Fixes #114.  Note that an abstract test is not defined here in WNM because of the external dependency of a topic (hence better off written as a functional test in [WIS2 Global Services Testing](https://wmo-im.github.io/wis2-global-services-testing/global-services-testing/wis2-global-services-testing-DRAFT.html#_notification_and_metadata_processing_record_deletion)).