### PR TITLE
update CI actions, add pywis-pubsub example in schemas README

### DIFF
--- a/.github/workflows/specification.yml
+++ b/.github/workflows/specification.yml
@@ -23,7 +23,7 @@ jobs:
           && sudo apt-get install -y pandoc \
           && sudo gem install asciidoctor asciidoctor-pdf
       - name: checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@master
       - name: build specification
         run: |
           cd standard \
@@ -39,7 +39,7 @@ jobs:
           && asciidoctor --trace -r asciidoctor-pdf --trace -b pdf -o /tmp/wis2-notification-message/kpi/${KPI_FILE_BASENAME}.pdf index.adoc \
           && cd ..
       - name: checkout gh-pages branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@master
         with:
           ref: gh-pages
       - name: update gh-pages branch and publish

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.10", 3.11]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@v5
       name: Setup Python ${{ matrix.python-version }}
       with:
         python-version: ${{ matrix.python-version }}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -38,6 +38,9 @@ include automated workflow via GitHub Actions.
 # install the check-jsonschema Python package
 pip3 install check-jsonschema
 
-# validate a WWIS2 Notification Message on the command line
+# validate a WIS2 Notification Message on the command line using JSON Schema
 check-jsonschema --schemafile schemas/wis2-notification-message-bundled.json examples/example1.json
+
+# validate a WIS2 Notification Message against the WNM ETS for full compliance
+pywis-pubsub ets validate examples/example1.json
 ```


### PR DESCRIPTION
This PR updates various settings in our CI and adds a pywis-pubsub example in `schemas/` (no impact on specification).
