### PR TITLE
update Recommendation 1 to recommend data_id starts with WCMP2 id (#179)

### DIFF
--- a/standard/recommendations/core/REC_data_id.adoc
+++ b/standard/recommendations/core/REC_data_id.adoc
@@ -2,6 +2,6 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/data_id*
-^|A |The `+properties.data_id+` property SHOULD NOT use an opaque id. It should be encoded with meaningful values to support client-side filtering.
+^|A |The `+properties.data_id+` property SHOULD start with the value of the WCMP2 metadata identifier.
 |===
 //rec1  


### PR DESCRIPTION
As per ET-W2IT 2026-06 action:

> replace Recommendation 1 with a recommendation to start data-id with the wcmp2 metadata-id.

cc @josusky @solson-nws 